### PR TITLE
Make filter and sort options synchronize to URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       $watch('labelFilter', (value) => {
         const url = new URL(window.location.href);
         if (value === '') {
-          url.searchParams.delete('filter', value);
+          url.searchParams.delete('filter');
         } else {
           url.searchParams.set('filter', value);
         }
@@ -33,7 +33,7 @@
       $watch('sort', (value) => {
         const url = new URL(window.location.href);
         if (value === '') {
-          url.searchParams.delete('sort', value);
+          url.searchParams.delete('sort');
         } else {
           url.searchParams.set('sort', value);
         }

--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
             <option value="platform:uwp" title="Universal Windows Platform">UWP</option>
           </optgroup>
         </select>
-        <span :style="`margin-left: 1rem; font-weight: ${labelSort === '' ? 400 : 700}`">Sort:</span>
-        <select x-model="labelSort">
+        <span :style="`margin-left: 1rem; font-weight: ${sort === '' ? 400 : 700}`">Sort:</span>
+        <select x-model="sort">
           <option value="" title="Sort proposals by popularity">Popularity</option>
           <option value="newest" title="Sort proposals by newest first">Newest</option>
           <option value="oldest" title="Sort proposals by oldest first">Oldest</option>
@@ -159,16 +159,15 @@
           // Becomes `true` if proposals are successfully loaded.
           proposalsLoaded: false,
           // The GitHub issue label to filter the list of proposals.
-          labelFilter: '',
-          labelSort: '',
+          sort: '',
 
           proposalsFiltered() {
             let sortMethod;
-            if (this.labelSort == '') {
+            if (this.sort == '') {
               sortMethod = this.sortProposalsPopularity;
-            } else if (this.labelSort == 'newest') {
+            } else if (this.sort == 'newest') {
               sortMethod = this.sortProposalsNewest;
-            } else if (this.labelSort == 'oldest') {
+            } else if (this.sort == 'oldest') {
               sortMethod = this.sortProposalsOldest;
             }
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,27 @@
       or by newest or oldest.
     </p>
     <p><a href="https://github.com/Calinou/godot-proposals-viewer">Contribute to this proposal viewer on GitHub!</a></p>
-    <div x-data="table()" x-init="loadProposals()">
+    <div x-data="table()" x-init="
+      $watch('labelFilter', (value) => {
+        const url = new URL(window.location.href);
+        if (value === '') {
+          url.searchParams.delete('filter', value);
+        } else {
+          url.searchParams.set('filter', value);
+        }
+        history.pushState(null, document.title, url.toString());
+      })
+      $watch('sort', (value) => {
+        const url = new URL(window.location.href);
+        if (value === '') {
+          url.searchParams.delete('sort', value);
+        } else {
+          url.searchParams.set('sort', value);
+        }
+        history.pushState(null, document.title, url.toString());
+      })
+      loadProposals()
+    ">
       <template x-if="proposalsLoaded">
 
         <!-- Attract user attention if filter has been changed from the default (All proposals). -->
@@ -153,13 +173,15 @@
     </div>
 
     <script>
+      let searchParams = new URLSearchParams(location.search);
       function table() {
         return {
           proposals: [],
           // Becomes `true` if proposals are successfully loaded.
           proposalsLoaded: false,
           // The GitHub issue label to filter the list of proposals.
-          sort: '',
+          labelFilter: searchParams.get('filter') || '',
+          sort: searchParams.get('sort') || '',
 
           proposalsFiltered() {
             let sortMethod;


### PR DESCRIPTION
Allows refreshing page with selections not resetting or to share selections like https://godot-proposals-viewer.github.io/?sort=newest

Also renames 'labelSort' property to 'sort'

Bugs:
- Pressing the back button doesn't actually take you back