### PR TITLE
Improve viewing on small displays

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -83,3 +83,15 @@ code {
   background-color: hsla(0, 0%, 60%, 0.2);
   padding: 0.125rem;
 }
+
+@media only screen and (max-width: 650px) {
+  td {
+    display: inline-block;
+  }
+  .headers {
+    display: none;
+  }
+  .score-cell {
+    padding-left: 4.0625rem;
+  }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -92,12 +92,15 @@ code {
   td {
     display: inline-block;
   }
+
   .headers {
     display: none;
   }
+
   .score-cell {
     padding-left: 4.0625rem;
   }
+
   .open-proposals {
     display: block;
     margin-left: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -84,6 +84,10 @@ code {
   padding: 0.125rem;
 }
 
+.open-proposals {
+  margin-left: 1rem;
+}
+
 @media only screen and (max-width: 650px) {
   td {
     display: inline-block;
@@ -93,5 +97,9 @@ code {
   }
   .score-cell {
     padding-left: 4.0625rem;
+  }
+  .open-proposals {
+    display: block;
+    margin-left: 0;
   }
 }

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           <option value="newest" title="Sort proposals by newest first">Newest</option>
           <option value="oldest" title="Sort proposals by oldest first">Oldest</option>
         </select>
-        <a :href="`https://github.com/godotengine/godot-proposals/issues${(labelFilter !== '' ? `/labels/${labelFilter}` : '')}`" target="_blank" rel="noreferrer noopener" style="margin-left: 1rem" >
+        <a class= "open-proposals" :href="`https://github.com/godotengine/godot-proposals/issues${(labelFilter !== '' ? `/labels/${labelFilter}` : '')}`" target="_blank" rel="noreferrer noopener" >
           <span x-text="`${proposalsFiltered().length} open proposals`"></span>
         </a>
 

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           <option value="newest" title="Sort proposals by newest first">Newest</option>
           <option value="oldest" title="Sort proposals by oldest first">Oldest</option>
         </select>
-        <a class= "open-proposals" :href="`https://github.com/godotengine/godot-proposals/issues${(labelFilter !== '' ? `/labels/${labelFilter}` : '')}`" target="_blank" rel="noreferrer noopener" >
+        <a :href="`https://github.com/godotengine/godot-proposals/issues${(labelFilter !== '' ? `/labels/${labelFilter}` : '')}`" target="_blank" rel="noreferrer noopener" class="open-proposals">
           <span x-text="`${proposalsFiltered().length} open proposals`"></span>
         </a>
 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
         </a>
 
         <table>
-          <thead>
+          <thead class="headers">
             <tr>
               <!--
                 Align the Title header to the actual issue title, since the leftmost
@@ -107,7 +107,7 @@
                     :title="`#${proposal.number}&#10;Opened by ${proposal.user.login} ${Math.floor((Math.floor(Date.now() / 1000) - Math.floor(Date.parse(proposal.created_at) / 1000)) / 86400)} days ago`"
                   ></a>
                 </td>
-                <td style="min-width: 200px;">
+                <td class="score-cell" style="min-width: 200px;">
                   <span x-text="`+${proposal.reactions['+1']}`" :style="`
                     color: var(--green);
                     font-weight: ${proposal.reactions['+1'] >= 30 ? '700' : '400'};


### PR DESCRIPTION
Makes open proposals a block on small displays so it doesn't have to wrap
Merges the title and score together & hides the headers on small displays
| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/12120644/118280744-7cff4700-b49a-11eb-9387-e2055a7eddfc.png) | ![image](https://user-images.githubusercontent.com/12120644/118280780-82f52800-b49a-11eb-9634-07bd416dd772.png) |

