### PR TITLE
Use new GitHub actions workflow for publishing to pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,34 @@
 name: Continuous integration
 on:
   push:
+    branches:
+      - master # Only master is allowed to deploy to pages
   schedule:
     # Every day at midnight (UTC).
     # This keeps the list of proposals fresh.
     - cron: '0 0 * * *'
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
-  deploy:
-    name: Build and deploy to GitHub Pages
+  # Build job
+  build:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
 
       - name: Fetch list of proposals
         run: |
@@ -30,13 +46,19 @@ jobs:
           tar xf minify_linux_amd64.tar.gz minify
           ./minify --recursive dist --output .
 
-      - name: Deploy to GitHub Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The branch the action should deploy to.
-          BRANCH: gh-pages
-          # The folder the action should deploy.
-          FOLDER: dist
-          # Artifacts are large, don't keep the branch's history
-          SINGLE_COMMIT: true
+          path: dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This was mainly just for experimenting with the new feature but you can merge if you like.  See https://github.com/foxydevloper/godot-proposals-viewer.github.io/actions/runs/2767856122 for it in action.
This deploys pages directly from the action, rather than it uploading the final build to a separate branch.
https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/