### PR TITLE
Fix Off-by-One Error in Filter Dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,23 +62,24 @@
               <option value="10">GDExtension</option>
               <option value="11">GDScript</option>
               <option value="12" title="Graphical User Interface">GUI</option>
-              <option value="13" title="Resource importing system and asset pipeline">Import</option>
-              <option value="14">Input</option>
-              <option value="15">Mono/.NET (C#)</option>
-              <option value="16">Navigation</option>
-              <option value="17">Network</option>
-              <option value="18">Physics</option>
-              <option value="19" title="Editor plugins">Plugin</option>
-              <option value="20">Platforms</option>
-              <option value="21">Rendering</option>
-              <option value="22" title="Godot shader language">Shaders</option>
-              <option value="23" title="Unit testing / integration testing">Tests</option>
-              <option value="24">VisualScript</option>
-              <option value="25">XR</option>
-              <option value="26" title="Any proposal related to 2D">2D</option>
-              <option value="27" title="Any proposal related to 3D">3D</option>
-              <option value="28">Particles</option>
-              <option value="29" title="High-level multiplayer API (RPCs, ENet)">Multiplayer</option>
+              <option value="13" title="Internationalization">i18n</option>
+              <option value="14" title="Resource importing system and asset pipeline">Import</option>
+              <option value="15">Input</option>
+              <option value="16">Mono/.NET (C#)</option>
+              <option value="17">Navigation</option>
+              <option value="18">Network</option>
+              <option value="19">Physics</option>
+              <option value="20" title="Editor plugins">Plugin</option>
+              <option value="21">Platforms</option>
+              <option value="22">Rendering</option>
+              <option value="23" title="Godot shader language">Shaders</option>
+              <option value="24" title="Unit testing / integration testing">Tests</option>
+              <option value="25">VisualScript</option>
+              <option value="26">XR</option>
+              <option value="27" title="Any proposal related to 2D">2D</option>
+              <option value="28" title="Any proposal related to 3D">3D</option>
+              <option value="29">Particles</option>
+              <option value="30" title="High-level multiplayer API (RPCs, ENet)">Multiplayer</option>
             </optgroup>
             <optgroup label="Type">
               <option value="70">Usability</option>


### PR DESCRIPTION
This addresses issue https://github.com/godot-proposals-viewer/godot-proposals-viewer.github.io/issues/32

Fixed by adding the missing "i18n" (Internationalization) option in the dropdown fields, which are pulled from         `getLabelName(labelCode)` in the `index.html`, but missing from the Topic dropdown, causing the off-by-one issue.

### Before:
<img width="993" height="355" alt="image" src="https://github.com/user-attachments/assets/1fee9fae-cc7f-4b56-85e2-5aaf99adfd0a" />

### After:
<img width="1792" height="1143" alt="image" src="https://github.com/user-attachments/assets/698d2864-d7ac-411d-a552-e1df31abe93d" />


**Thank you to @AndrooDev in the discord for pointing this out!!**
