### PR TITLE
Remove meter and improve formatting of upvotes/downvotes/comments.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -88,6 +88,30 @@ code {
   margin-left: 1rem;
 }
 
+span.upvotes-count {
+  color: var(--green);
+  font-weight: 400;
+  display:inline-block;
+  min-width: 3.5em;
+  text-align: right;
+}
+
+span.downvotes-count {
+  color: var(--red);
+  font-weight: 400;
+  margin-left: 0.25rem;
+  display:inline-block;
+  min-width: 2em;
+  text-align: right;
+}
+
+span.comments-count {
+  font-weight: 400;
+  display:inline-block;
+  min-width: 5em;
+  text-align: right;
+}
+
 @media only screen and (max-width: 650px) {
   td {
     display: inline-block;

--- a/css/main.css
+++ b/css/main.css
@@ -91,7 +91,7 @@ code {
 span.upvotes-count {
   color: var(--green);
   font-weight: 400;
-  display:inline-block;
+  display: inline-block;
   min-width: 3.5em;
   text-align: right;
 }
@@ -100,14 +100,14 @@ span.downvotes-count {
   color: var(--red);
   font-weight: 400;
   margin-left: 0.25rem;
-  display:inline-block;
+  display: inline-block;
   min-width: 2em;
   text-align: right;
 }
 
 span.comments-count {
   font-weight: 400;
-  display:inline-block;
+  display: inline-block;
   min-width: 5em;
   text-align: right;
 }

--- a/index.html
+++ b/index.html
@@ -143,33 +143,16 @@
                     ></a>
                   </td>
                   <!-- Set minimum width to allow proposals with 100+ positive votes, 10+ negative votes and 100+ comments to display the score cell on a single line. -->
-                  <td class="score-cell" style="min-width: 210px;">
-                    <span x-text="`+${proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE]}`" :style="`
-                      color: var(--green);
-                      font-weight: ${proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE] >= 40 ? '700' : '400'};
-                    `"></span>
-                    <span x-text="`-${proposal[KEY_REACTIONS][KEY_REACTIONS_NEGATIVE]}`" :style="`
-                      color: var(--red);
-                      font-weight: ${proposal[KEY_REACTIONS][KEY_REACTIONS_NEGATIVE] >= 5 ? '700' : '400'};
-                      margin-left: 0.25rem;
-                    `"></span>
-
-                    <!-- The bar is fully opaque with 20 +1 reactions or more. -->
-                    <meter
-                      min="0"
-                      :value="proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE]"
-                      :max="proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE] + proposal[KEY_REACTIONS][KEY_REACTIONS_NEGATIVE]"
-                      :style="`opacity: ${proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE] * 5}%; margin-left: 0.25rem;`"
-                    ></meter>
+                  <td class="score-cell" style="min-width: 200px;">
+                    <span x-text="`+${proposal[KEY_REACTIONS][KEY_REACTIONS_POSITIVE]}`" class="upvotes-count"></span>
+                    <span x-text="`-${proposal[KEY_REACTIONS][KEY_REACTIONS_NEGATIVE]}`" class="downvotes-count"></span>
 
                     <!-- The comments bubble is fully opaque with 30 comments or more. -->
                     <span
                       x-show="proposal[KEY_COMMENTS] >= 1"
-                      x-text="`💬 ${proposal[KEY_COMMENTS]}`"
-                      :style="`
-                      opacity: ${(0.25 + proposal[KEY_COMMENTS] / 40) * 100}%;
-                      font-weight: ${proposal[KEY_COMMENTS] >= 60 ? '700' : '400'};
-                    `"></span>
+                      x-text="`${proposal[KEY_COMMENTS]} 💬`"
+                      class="comments-count">
+                    </span>
                   </td>
                 </tr>
               </template>


### PR DESCRIPTION
The meter is almost always full green anyway. So there isn't much interesting information to get from it.
The difference between bold and not bold votes is arbitrary to me. I think the count is enough.

New look is nice and aligned:

<img width="270" height="193" alt="SCR-20260205-nvzf" src="https://github.com/user-attachments/assets/053088b9-7737-4fdd-bdd0-d2413b211584" />
