### PR TITLE
Update the website 4 times a day.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Every day at midnight (UTC).
-    # This keeps the list of proposals fresh.
-    - cron: '0 0 * * *'
+    # At the time of writing, we get about 2-6 new proposals a day, while
+    # the cronjob takes around 5 minutes to run.
+    # To keep proposals fresh, try to fetch them in a reasonable timeframe.
+    # The entries are staggered to avoid round numbers where high load is expected.
+    - cron: '50 2 * * *'
+    - cron: '50 8 * * *'
+    - cron: '50 14 * * *'
+    - cron: '50 20 * * *'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
 permissions:


### PR DESCRIPTION
Updating once a day is a bit rare. If the website is not updated, it might disincentivise using it.

Some of our other tools use 15 minute intervals to run, on an ~8 minute job (e.g. [PRs by file](https://github.com/godotengine/godot-prs-by-file/blob/master/.github/workflows/ci.yml)). It hasn't had problems so far.

I think every 15 minutes is a bit extreme for ~2-8 proposals a day, so I settled for a reasonable sounding 4 times a day.