### PR TITLE
Re-document how votes work.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
     <p>
       This page lists open <a href="https://github.com/godotengine/godot-proposals">Godot proposals</a>,
       with the ability to sort and filter in convenient ways.
+      Reactions on the proposals are interpreted as votes, with 👍 reactions counted as upvotes, and 👎 + 😕 reactions counted as downvotes.
+      Other reactions are ignored in this viewer.
+    </p>
+    <p>
       For performance reasons, this page does not show all proposals at once by default. You can change this
       using the selectors below.
     </p>


### PR DESCRIPTION
We had a user ask about this, so I was definitely in the wrong to remove it :D

For future reference, i intentionally did not add other "upvote" reactions because otherwise, we'd often be counting the same users multiple times. It is better to count diverse feedback from many users than strong feedback from a few.